### PR TITLE
Improving GPR usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,10 @@ This should be able to migrate packages from GitHub Enterprise Server to GitHub.
 1. [gh cli](https://cli.github.com) installed and logged in to be able to access the source GitHub instance (`gh auth login`)
 2. Auth to read packages from the source GitHub instance with `gh`, ie: `gh auth refresh -h github.com -s read:packages` (update `-h` with source github host)
 3. `<source-pat>` must have `read:packages` scope
-4. [gpr](https://github.com/jcansdale/gpr) installed: `dotnet tool install gpr -g`
-5. Can use this to find GPR path for `<path-to-gpr>`: `find / -wholename "*tools/gpr" 2> /dev/null`
-6. `<target-pat>` must have `write:packages` scope
-7. This assumes that the target org's repo name is the same as the source.
+4. `<target-pat>` must have `write:packages` scope
+5. This assumes that the target org's repo name is the same as the source.
 
-Passing `gpr` as a parameter explicitly because sometimes `gpr` is aliased to `git pull --rebase` and that's not what we want here
+This script installs [gpr](https://github.com/jcansdale/gpr) locally to the `./temp/tools` directory.
 
 ## Usage
 
@@ -24,8 +22,7 @@ Passing `gpr` as a parameter explicitly because sometimes `gpr` is aliased to `g
   <source-host> \
   <source-pat> \
   <target-org> \
-  <target-pat> \
-  <path-to-gpr>
+  <target-pat>
 ```
 
 ## Example
@@ -36,8 +33,7 @@ Passing `gpr` as a parameter explicitly because sometimes `gpr` is aliased to `g
   github.com \
   ghp_abc \
   joshjohanning-org-packages-migrated \
-  ghp_xyz \
-  /home/codespace/.dotnet/tools/gpr
+  ghp_xyz
 ```
 
 <details>
@@ -111,4 +107,4 @@ Passing `gpr` as a parameter explicitly because sometimes `gpr` is aliased to `g
 
 - Uses [jcansdale/gpr](https://github.com/jcansdale/gpr) to do the nuget push
 - Had to delete `_rels/.rels` and `[Content_Types].xml` because there was somehow two copies of each file in the package and it causes `gpr` to fail when extracting/zipping the package to re-push
-- Run this to clean up your working dir: `rm ./*.nupkg ./*.zip`
+- Run this to clean up your working directory: `rm -rf ./temp`

--- a/migrate-nuget-packages-between-orgs.sh
+++ b/migrate-nuget-packages-between-orgs.sh
@@ -29,6 +29,13 @@ TARGET_ORG=$4
 TARGET_PAT=$5 
 GPR_PATH=$6
 
+# check if GPR_PATH is valid
+if [ ! -f "$GPR_PATH" ]; then
+    echo "Error: $GPR_PATH does not exist"
+    echo "Install gpr with: dotnet tool install gpr -g"
+    exit 1
+fi
+
 packages=$(GH_HOST="$SOURCE_HOST" gh api "/orgs/$SOURCE_ORG/packages?package_type=nuget" -q '.[] | .name + " " + .repository.name')
 
 echo "$packages" | while IFS= read -r response; do

--- a/migrate-nuget-packages-between-orgs.sh
+++ b/migrate-nuget-packages-between-orgs.sh
@@ -7,16 +7,16 @@
 # 1. gh cli installed and logged in (`gh auth login`)
 # 2. Auth to read packages with gh, ie: `gh auth refresh -h github.com -s read:packages`
 # 3. `<source-pat>` must have `read:packages` scope
-# 4. gpr installed: `dotnet tool install gpr -g` (https://github.com/jcansdale/gpr)
-# 5. Can use this to find GPR path for `<path-to-gpr>`: `find / -wholename "*tools/gpr" 2> /dev/null`
-# 6. `<target-pat>` must have `write:packages` scope
-# 7. This assumes that the target org's repo name is the same as the source.
+# 4. `<target-pat>` must have `write:packages` scope
+# 5. This assumes that the target org's repo name is the same as the source.
 # 
-# Passing `gpr` as a parameter explicitly because sometimes `gpr` is aliased to `git pull --rebase` and that's not what we want here
+# This script installs [gpr](https://github.com/jcansdale/gpr) locally to the `./temp/tools` directory.
 #
 
-if [ -z "$6" ]; then
-    echo "Usage: $0 <source-org> <source-host> <souce-pat> <target-org> <target-pat> <path-to-gpr>"
+set -e
+
+if [ $# -ne "5" ]; then
+    echo "Usage: $0 <source-org> <source-host> <souce-pat> <target-org> <target-pat>"
     exit 1
 fi
 
@@ -26,14 +26,18 @@ SOURCE_ORG=$1
 SOURCE_HOST=$2
 SOURCE_PAT=$3
 TARGET_ORG=$4
-TARGET_PAT=$5 
-GPR_PATH=$6
+TARGET_PAT=$5
 
-# check if GPR_PATH is valid
+# create temp dir
+mkdir -p ./temp
+cd ./temp
+temp_dir=$(pwd)
+GPR_PATH="$temp_dir/tool/gpr"
+
+# install gpr locally
 if [ ! -f "$GPR_PATH" ]; then
-    echo "Error: $GPR_PATH does not exist"
-    echo "Install gpr with: dotnet tool install gpr -g"
-    exit 1
+  echo "Installing gpr locally to $GPR_PATH"
+  dotnet tool install gpr --tool-path ./tool
 fi
 
 packages=$(GH_HOST="$SOURCE_HOST" gh api "/orgs/$SOURCE_ORG/packages?package_type=nuget" -q '.[] | .name + " " + .repository.name')
@@ -62,4 +66,4 @@ echo "$packages" | while IFS= read -r response; do
 
 done
 
-echo "Run this to clean up your working dir: rm ./*.nupkg ./*.zip"
+echo "Run this to clean up your working dir: rm -rf ./temp"

--- a/migrate-nuget-packages-between-orgs.sh
+++ b/migrate-nuget-packages-between-orgs.sh
@@ -34,6 +34,13 @@ cd ./temp
 temp_dir=$(pwd)
 GPR_PATH="$temp_dir/tool/gpr"
 
+# check if dotnet is installed
+if ! command -v dotnet &> /dev/null
+then
+    echo "Error: dotnet could not be found"
+    exit
+fi
+
 # install gpr locally
 if [ ! -f "$GPR_PATH" ]; then
   echo "Installing gpr locally to $GPR_PATH"


### PR DESCRIPTION
- don't have to pass in gpr; it installs it locally
- uses `./temp` directory for artifacts
- checking to see if `dotnet` is installed
- `set -e` to fail script if error detected